### PR TITLE
Replaced "Trigger even if some downstream projects are unstable" check-box with drop-down list of statuses

### DIFF
--- a/src/main/java/join/JoinAction.java
+++ b/src/main/java/join/JoinAction.java
@@ -29,7 +29,7 @@ public class JoinAction implements Action {
     private List<String> consideredBuilds;
     private transient String joinProjects;
     private DescribableList<Publisher, Descriptor<Publisher>> joinPublishers;
-    private boolean evenIfDownstreamUnstable;
+    private Result resultThreshold;
     private Result overallResult;
 
     public JoinAction(JoinTrigger joinTrigger, List<AbstractProject<?,?>> downstream) {
@@ -41,7 +41,7 @@ public class JoinAction implements Action {
         }
         this.joinProjects = joinTrigger.getJoinProjectsValue();
         this.joinPublishers = joinTrigger.getJoinPublishers();
-        this.evenIfDownstreamUnstable = joinTrigger.getEvenIfDownstreamUnstable();
+        this.resultThreshold = joinTrigger.getResultThreshold();
         this.completedDownstreamProjects = new LinkedList<String>();
         this.consideredBuilds = new LinkedList<String>();
         this.overallResult = Result.SUCCESS;
@@ -82,8 +82,7 @@ public class JoinAction implements Action {
     public synchronized void checkPendingDownstream(AbstractBuild<?,?> owner, TaskListener listener) {
         if(pendingDownstreamProjects.isEmpty()) {
             listener.getLogger().println("All downstream projects complete!");
-            Result threshold = this.evenIfDownstreamUnstable ? Result.UNSTABLE : Result.SUCCESS;
-            if(this.overallResult.isWorseThan(threshold)) {
+            if(this.overallResult.isWorseThan(this.resultThreshold)) {
                 listener.getLogger().println("Minimum result threshold not met for join project");
             } else {
                 // Construct a launcher since CopyArchiver wants to get the

--- a/src/main/java/join/JoinTriggerDependency.java
+++ b/src/main/java/join/JoinTriggerDependency.java
@@ -8,17 +8,16 @@ import hudson.model.Result;
 * @author wolfs
 */
 class JoinTriggerDependency extends JoinDependency<DependencyGraph.Dependency> {
-    boolean evenIfDownstreamUnstable;
-    JoinTriggerDependency(AbstractProject<?, ?> upstream, AbstractProject<?, ?> downstream, AbstractProject<?, ?> splitProject, boolean evenIfDownstreamUnstable) {
+    Result resultThreshold;
+    JoinTriggerDependency(AbstractProject<?, ?> upstream, AbstractProject<?, ?> downstream, AbstractProject<?, ?> splitProject, Result resultThreshold) {
         super(upstream, downstream, splitProject);
-        this.evenIfDownstreamUnstable = evenIfDownstreamUnstable;
+        this.resultThreshold = resultThreshold;
         splitDependency = new DependencyGraph.Dependency(splitProject, downstream);
     }
 
     @Override
     protected boolean conditionIsMet(Result overallResult) {
-        Result threshold = this.evenIfDownstreamUnstable ? Result.UNSTABLE : Result.SUCCESS;
-        return overallResult.isBetterOrEqualTo(threshold);
+        return overallResult.isBetterOrEqualTo(this.resultThreshold);
     }
 
     @Override
@@ -33,7 +32,7 @@ class JoinTriggerDependency extends JoinDependency<DependencyGraph.Dependency> {
             return false;
         }
         final JoinTriggerDependency other = (JoinTriggerDependency) obj;
-        if (this.evenIfDownstreamUnstable != other.evenIfDownstreamUnstable) {
+        if (this.resultThreshold != other.resultThreshold) {
             return false;
         }
         return true;
@@ -43,7 +42,7 @@ class JoinTriggerDependency extends JoinDependency<DependencyGraph.Dependency> {
     public int hashCode() {
         int hash = 3;
         hash = 71 * hash + super.hashCode();
-        hash = 71 * hash + (this.evenIfDownstreamUnstable ? 1 : 0);
+        hash = 71 * hash + this.resultThreshold.ordinal;
         return hash;
     }
 }

--- a/src/main/resources/join/JoinTrigger/config.jelly
+++ b/src/main/resources/join/JoinTrigger/config.jelly
@@ -1,8 +1,13 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <j:if test="${descriptor.showEvenIfUnstableOption(targetType)}">
-    <f:entry title="" help="/plugin/join/help/evenUnstable.html">
-      <f:checkbox id="buildTrigger.evenIfDownstreamUnstable" name="buildTrigger.evenIfDownstreamUnstable" checked="${instance.evenIfDownstreamUnstable}" />
-      <label class="attach-previous">${%Trigger even if some downstream projects are unstable}</label>
+  <j:if test="${descriptor.showResultThresholdOption(targetType)}">
+    <f:entry title="" help="/plugin/join/help/resultThreshold.html" field="buildTrigger.resultThreshold">
+		<select class="setting-input" name="buildTrigger.resultThreshold">
+			<f:option value="SUCCESS" selected="${instance.resultThreshold.toString()=='SUCCESS'}">SUCCESS</f:option>
+			<f:option value="UNSTABLE" selected="${instance.resultThreshold.toString()=='UNSTABLE'}">UNSTABLE</f:option>
+			<f:option value="FAILURE" selected="${instance.resultThreshold.toString()=='FAILURE'}">FAILURE</f:option>
+			<f:option value="ABORTED" selected="${instance.resultThreshold.toString()=='ABORTED'}">ABORTED</f:option>
+		</select>
+      <label class="attach-previous">${%Trigger even if some downstream projects have results}</label>
     </f:entry>
   </j:if>
   <f:entry title="${%Projects to build once, after all downstream projects have finished}"

--- a/src/main/webapp/help/resultThreshold.html
+++ b/src/main/webapp/help/resultThreshold.html
@@ -1,0 +1,4 @@
+<div>
+Result threshold of the downstream projects to be checked.
+The join projects will be started only when all downstream projects have results that are better then selected.
+</div>

--- a/src/test/java/join/BasicJoinPluginTest.java
+++ b/src/test/java/join/BasicJoinPluginTest.java
@@ -119,7 +119,7 @@ public abstract class BasicJoinPluginTest extends HudsonTestCase {
             projects.add(project.getName());
         }
         splitProject.getPublishersList().add(new JoinTrigger(new DescribableList<Publisher, Descriptor<Publisher>>(
-                Saveable.NOOP), StringUtils.join(projects,","), false));
+                Saveable.NOOP), StringUtils.join(projects,","), "SUCCESS"));
     }
 
     public static void addParameterizedJoinTriggerToProject(AbstractProject<?,?> splitProject, AbstractProject<?,?> joinProject, AbstractBuildParameters... params) throws Exception {
@@ -129,7 +129,7 @@ public abstract class BasicJoinPluginTest extends HudsonTestCase {
     public static void addParameterizedJoinTriggerToProject(AbstractProject<?,?> splitProject, AbstractProject<?,?> joinProject, ResultCondition condition, AbstractBuildParameters... params) throws Exception {
         final BuildTriggerConfig config = new hudson.plugins.parameterizedtrigger.BuildTriggerConfig(joinProject.getName(), condition, params);
         splitProject.getPublishersList().add(new JoinTrigger(new DescribableList<Publisher, Descriptor<Publisher>>(
-                Saveable.NOOP, Collections.singletonList(new hudson.plugins.parameterizedtrigger.BuildTrigger(config))),"",false));
+                Saveable.NOOP, Collections.singletonList(new hudson.plugins.parameterizedtrigger.BuildTrigger(config))),"","SUCCESS"));
     }
 
     public static void addProjectToSplitProject(AbstractProject<?,?> splitProject, AbstractProject<?,?> projectToAdd) throws Exception {

--- a/src/test/java/join/JoinTriggerTest.java
+++ b/src/test/java/join/JoinTriggerTest.java
@@ -198,7 +198,7 @@ public class JoinTriggerTest extends BasicJoinPluginTest {
         final JoinTrigger before = new JoinTrigger(
                 new DescribableList<Publisher, Descriptor<Publisher>>(Saveable.NOOP),
                 joinProject.getName(),
-                false);
+                "SUCCESS");
         splitProject.getPublishersList().add(before);
         final WebClient webClient = createWebClient();
         webClient.setThrowExceptionOnFailingAjax(false);
@@ -208,7 +208,7 @@ public class JoinTriggerTest extends BasicJoinPluginTest {
         final JoinTrigger after = splitProject.getPublishersList().get(JoinTrigger.class);
 
         assertEquals(before.getJoinProjectsValue(),after.getJoinProjectsValue());
-        assertEquals(before.getEvenIfDownstreamUnstable(), after.getEvenIfDownstreamUnstable());
+        assertEquals(before.getResultThreshold(), after.getResultThreshold());
         assertEquals(0, after.getJoinPublishers().size());
     }
 
@@ -224,7 +224,7 @@ public class JoinTriggerTest extends BasicJoinPluginTest {
         final JoinTrigger after = splitProject.getPublishersList().get(JoinTrigger.class);
 
         assertEquals(before.getJoinProjectsValue(),after.getJoinProjectsValue());
-        assertEquals(before.getEvenIfDownstreamUnstable(), after.getEvenIfDownstreamUnstable());
+        assertEquals(before.getResultThreshold(), after.getResultThreshold());
         assertEquals(1, after.getJoinPublishers().size());
         final hudson.plugins.parameterizedtrigger.BuildTrigger paramBtBefore = before.getJoinPublishers().get(hudson.plugins.parameterizedtrigger.BuildTrigger.class);
         final hudson.plugins.parameterizedtrigger.BuildTrigger paramBtAfter = after.getJoinPublishers().get(hudson.plugins.parameterizedtrigger.BuildTrigger.class);


### PR DESCRIPTION
Added a possibility to configure JoinTrigger to start post-join job when status of the downstream job is FAILURE or ABORTED.
