### PR TITLE
Removing integration with deprecated copyarchiver plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,18 +42,6 @@
       <artifactId>maven-plugin</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.jvnet.hudson.plugins</groupId>
-      <artifactId>copyarchiver</artifactId>
-      <version>0.5.1</version>
-      <optional>true</optional>
-      <exclusions>
-          <exclusion>
-              <groupId>org.jvnet.hudson.main</groupId>
-              <artifactId>maven-plugin</artifactId>
-          </exclusion>
-      </exclusions>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/src/main/java/join/JoinTrigger.java
+++ b/src/main/java/join/JoinTrigger.java
@@ -332,10 +332,6 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
             if (parameterizedTrigger != null) {
                 list.add(Hudson.getInstance().getDescriptorByType(hudson.plugins.parameterizedtrigger.BuildTrigger.DescriptorImpl.class));
             }
-            Plugin copyArchiver = Hudson.getInstance().getPlugin("copyarchiver");
-            if (copyArchiver != null) {
-                list.add(Hudson.getInstance().getDescriptorByType(com.thalesgroup.hudson.plugins.copyarchiver.CopyArchiverPublisher.CopyArchiverDescriptor.class));
-            }
             // See issue 4384.  Supporting the mailer here breaks its use as the regular post-build action.
             //list.add(Hudson.getInstance().getDescriptorByType(hudson.tasks.Mailer.DescriptorImpl.class));
             return list;


### PR DESCRIPTION
If nothing else, the presence of this dependency causes the wiki page for this (Join) plugin to not show the correct plugin metadata.