### PR TITLE
Fix for Jenkins #16201

### DIFF
--- a/src/main/java/join/JoinAction.java
+++ b/src/main/java/join/JoinAction.java
@@ -71,6 +71,11 @@ public class JoinAction implements Action {
             } else {
                 listener.getLogger().println("[Join] Pending does not contain " + finishedBuildProjectName);
             }
+            try {
+                upstreamBuild.save();
+            } catch (java.io.IOException e) {
+                listener.getLogger().printf("Unable to save upstream build.");
+            }
         }
         return pendingDownstreamProjects.isEmpty();
     }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-16201
In some cases, Jenkins will swap out the action map for a build. For the Join plugin, it means that information about completed tasks is lost when it's re-read from disk. Saving the parent build ensures that the current state of the join action.