### PR TITLE
(Bug Fixed!)JENKINS-28709 Join Plugin ignores dependencies wrapped with flexible-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
       <version>2.12</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>flexible-publish</artifactId>
+      <version>0.15.2</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>flexible-publish</artifactId>
       <version>0.15.2</version>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/src/main/java/join/JoinTrigger.java
+++ b/src/main/java/join/JoinTrigger.java
@@ -218,6 +218,12 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
         
         DescribableList<Publisher, Descriptor<Publisher>> publishers = project.getPublishersList();
         List<AbstractProject<?, ?>> ret = new ArrayList<AbstractProject<?, ?>>();
+        Plugin flexiblePublisherPlugin = Jenkins.getInstance().getPlugin("flexible-publish");
+        Plugin parameterizedTrigger = Jenkins.getInstance().getPlugin("parameterized-trigger");
+        
+        if (flexiblePublisherPlugin == null || parameterizedTrigger == null) {
+        	return ret;
+        }
         
         FlexiblePublisher flexiblePublisher = publishers.get(FlexiblePublisher.class);
         
@@ -227,7 +233,7 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
                 for (BuildStep buildStep : conditionalPublisher.getPublisherList()) {
                     if (buildStep instanceof hudson.plugins.parameterizedtrigger.BuildTrigger) {
                     
-                        ret.addAll(GetProjectFromBuildTriggerConfigs((hudson.plugins.parameterizedtrigger.BuildTrigger)buildStep));
+                        ret.addAll(GetProjectFromBuildTriggerConfigs(buildStep));
                     }
                 }
             }
@@ -237,13 +243,13 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
     }
 
     private Collection<? extends AbstractProject<?, ?>> GetProjectFromBuildTriggerConfigs(
-            hudson.plugins.parameterizedtrigger.BuildTrigger buildTrigger) {
+            Object buildTrigger) {
         
         List<AbstractProject<?, ?>> ret = new ArrayList<AbstractProject<?, ?>>();
         
         for (hudson.model.Project p : Hudson.getInstance().getProjects()) {
     
-            for (BuildTriggerConfig config : buildTrigger.getConfigs()) {
+            for (BuildTriggerConfig config : ((hudson.plugins.parameterizedtrigger.BuildTrigger )buildTrigger).getConfigs()) {
                 if (p.getName().equals(config.getProjects())) {
                     ret.add(p);
                 }

--- a/src/main/java/join/JoinTrigger.java
+++ b/src/main/java/join/JoinTrigger.java
@@ -64,12 +64,15 @@ import hudson.util.FormValidation;
 import join.JoinAction.JoinCause;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
+import org.jenkins_ci.plugins.flexible_publish.ConditionalPublisher;
+import org.jenkins_ci.plugins.flexible_publish.FlexiblePublisher;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
@@ -210,6 +213,46 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
         return ret;
     }
 
+    private Collection<? extends AbstractProject<?, ?>> getParameterizedDownstreamInFlexiblePublisher(
+        AbstractProject<?, ?> project) {
+        
+        DescribableList<Publisher, Descriptor<Publisher>> publishers = project.getPublishersList();
+        List<AbstractProject<?, ?>> ret = new ArrayList<AbstractProject<?, ?>>();
+        
+        FlexiblePublisher flexiblePublisher = publishers.get(FlexiblePublisher.class);
+        
+        if (flexiblePublisher != null ) {
+        
+            for (ConditionalPublisher conditionalPublisher : flexiblePublisher.getPublishers()) {
+                for (BuildStep buildStep : conditionalPublisher.getPublisherList()) {
+                    if (buildStep instanceof hudson.plugins.parameterizedtrigger.BuildTrigger) {
+                    
+                        ret.addAll(GetProjectFromBuildTriggerConfigs((hudson.plugins.parameterizedtrigger.BuildTrigger)buildStep));
+                    }
+                }
+            }
+        }
+        
+        return ret;
+    }
+
+    private Collection<? extends AbstractProject<?, ?>> GetProjectFromBuildTriggerConfigs(
+            hudson.plugins.parameterizedtrigger.BuildTrigger buildTrigger) {
+        
+        List<AbstractProject<?, ?>> ret = new ArrayList<AbstractProject<?, ?>>();
+        
+        for (hudson.model.Project p : Hudson.getInstance().getProjects()) {
+    
+            for (BuildTriggerConfig config : buildTrigger.getConfigs()) {
+                if (p.getName().equals(config.getProjects())) {
+                    ret.add(p);
+                }
+            }
+        }
+        
+        return ret;
+    }
+
     static boolean canDeclare(AbstractProject<?,?> owner) {
             // Inner class added in Hudson 1.341
             return true;
@@ -218,10 +261,12 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
 
     public List<AbstractProject<?,?>> getAllDownstream(AbstractProject<?,?> project, EnvVars env) {
         List<AbstractProject<?,?>> downstream = getBuildTriggerDownstream(project);
+        downstream.addAll(getParameterizedDownstreamInFlexiblePublisher(project));
         downstream.addAll(getParameterizedDownstreamProjects(project.getParent(), project.getPublishersList(), env));
         downstream.addAll(getDownstreamExtDownstream(project.getParent(), project.getPublishersList()));
         return downstream;
     }
+    
 
     public List<AbstractProject<?,?>> getBuildTriggerDownstream(AbstractProject<?,?> project) {
         ArrayList<AbstractProject<?,?>> ret = new ArrayList<AbstractProject<?,?>>();


### PR DESCRIPTION
Fix bug [JENKINS-28709](https://issues.jenkins-ci.org/browse/JENKINS-28709)
Now it can handle "hudson.plugins.parameterizedtrigger.BuildTrigger"  in Flexible publisher!