### PR TITLE
[FIX JENKINS-41115] Make Matrix Project Plugin dependency mandatory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
       <version>1.6</version>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
… because it clearly is:
https://github.com/jenkinsci/join-plugin/blob/e8b1c0023f0d8e8e56aadbd7189f6be4dc6b80e0/src/main/java/join/JoinTrigger.java#L85