### PR TITLE
Modernize plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target/
 /work/
+
+# IntelliJ IDEA
+.idea/
+*.iml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// for http://ci.jenkins.io/
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.600</version>
+    <version>2.35</version>
   </parent>
 
   <artifactId>join</artifactId>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
-      <version>1.6</version>
+      <version>1.12-20171002.212938-3</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -50,11 +50,23 @@
       <version>1.7</version>
       <optional>true</optional>
     </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.main</groupId>
+          <artifactId>jenkins-test-harness-tools</artifactId>
+          <version>2.2</version>
+          <scope>test</scope>
+      </dependency>
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
-      <version>2.12</version>
+      <version>2.7</version>
       <optional>true</optional>
+        <exclusions>
+            <exclusion>
+                <artifactId>ant</artifactId>
+                <groupId>org.apache.ant</groupId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/join/Items.java
+++ b/src/main/java/join/Items.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang.StringUtils;
 import java.util.*;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class Items {
 

--- a/src/main/java/join/JoinItemListener.java
+++ b/src/main/java/join/JoinItemListener.java
@@ -11,7 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Extension
 public class JoinItemListener extends ItemListener {

--- a/src/main/java/join/JoinTrigger.java
+++ b/src/main/java/join/JoinTrigger.java
@@ -28,9 +28,6 @@ import hudson.Extension;
 import hudson.Launcher;
 import hudson.Plugin;
 import hudson.Util;
-import hudson.matrix.MatrixAggregatable;
-import hudson.matrix.MatrixAggregator;
-import hudson.matrix.MatrixBuild;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
@@ -75,14 +72,13 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import jenkins.model.Jenkins;
 
 @Extension
-public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAggregatable {
+public class JoinTrigger extends Recorder implements DependecyDeclarer {
     private static final Logger LOGGER = Logger.getLogger(JoinTrigger.class.getName());
 
 
@@ -285,16 +281,6 @@ public class JoinTrigger extends Recorder implements DependecyDeclarer, MatrixAg
             }
         }
         return ret;
-    }
-
-    @Override
-    public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
-        return new MatrixAggregator(build, launcher, listener) {
-            @Override
-            public boolean endBuild() throws InterruptedException, IOException {
-                return perform(build,launcher,listener);
-            }
-        };
     }
 
     public boolean onJobRenamed(ItemGroup parent, String oldName, String newName) {

--- a/src/main/java/join/MatrixJoinTrigger.java
+++ b/src/main/java/join/MatrixJoinTrigger.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2004-2017, Sun Microsystems, Inc., Kohsuke Kawaguchi, Brian Westrich, Martin Eigenbrodt, Daniel Beck
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package join;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.matrix.MatrixAggregatable;
+import hudson.matrix.MatrixAggregator;
+import hudson.matrix.MatrixBuild;
+import hudson.model.BuildListener;
+
+import java.io.IOException;
+
+@Extension(optional = true)
+public class MatrixJoinTrigger implements MatrixAggregatable {
+    public MatrixAggregator createAggregator(MatrixBuild build, Launcher launcher, BuildListener listener) {
+        return new MatrixAggregator(build, launcher, listener) {
+            @Override
+            public boolean endBuild() throws InterruptedException, IOException {
+                JoinTrigger publisher = build.getParent().getPublishersList().get(JoinTrigger.class);
+                return publisher == null || publisher.perform(build, launcher, listener);
+            }
+        };
+    }
+}

--- a/src/main/resources/join/JoinTrigger/config.jelly
+++ b/src/main/resources/join/JoinTrigger/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default="true" ?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <j:if test="${descriptor.showResultThresholdOption(targetType)}">
     <f:entry title="" help="/plugin/join/help/resultThreshold.html" field="buildTrigger.resultThreshold">

--- a/src/test/java/join/ItemsTest.java
+++ b/src/test/java/join/ItemsTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class ItemsTest {
 

--- a/src/test/java/join/JoinTriggerAllCombinationsTest.java
+++ b/src/test/java/join/JoinTriggerAllCombinationsTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.jvnet.hudson.test.ExtractResourceSCM;
+import org.jvnet.hudson.test.ToolInstallations;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,6 +30,7 @@ import java.util.logging.Logger;
 @RunWith(Parameterized.class)
 public class JoinTriggerAllCombinationsTest extends BasicJoinPluginTest {
     Logger LOG = Logger.getLogger(JoinTriggerAllCombinationsTest.class.getName());
+    private static int i = 0;
 
     public static Map<Class<? extends AbstractProject<?,?>>, Function<JoinTriggerAllCombinationsTest,AbstractProject<?,?>>> projectType2Supplier =
             ImmutableMap.<Class<? extends AbstractProject<?,?>>, Function<JoinTriggerAllCombinationsTest,AbstractProject<?,?>>>of(
@@ -47,7 +49,7 @@ public class JoinTriggerAllCombinationsTest extends BasicJoinPluginTest {
                         @Override
                         public AbstractProject<?, ?> apply(JoinTriggerAllCombinationsTest from) {
                             try {
-                                MavenModuleSet mavenProject = from.createMavenProject();
+                                MavenModuleSet mavenProject = from.jenkins.createProject(MavenModuleSet.class, "maven" + i++);
                                 mavenProject.setQuietPeriod(0);
                                 mavenProject.setScm(new ExtractResourceSCM(getClass().getResource("maven-empty-mod.zip")));
 
@@ -62,7 +64,7 @@ public class JoinTriggerAllCombinationsTest extends BasicJoinPluginTest {
                         @Override
                         public AbstractProject<?, ?> apply(JoinTriggerAllCombinationsTest from) {
                             try {
-                                MatrixProject matrixProject = from.createMatrixProject();
+                                MatrixProject matrixProject = from.jenkins.createProject(MatrixProject.class, "matrix" + i++);
                                 matrixProject.setQuietPeriod(0);
                                 return matrixProject;
                             } catch (Exception e) {
@@ -114,7 +116,7 @@ public class JoinTriggerAllCombinationsTest extends BasicJoinPluginTest {
     @Test
     public void joinProjectShouldBeTriggered() throws Exception {
         assertNotNull(splitProject);
-        configureDefaultMaven();
+        ToolInstallations.configureDefaultMaven();
         AbstractProject<?,?> splitProject = projectType2Supplier.get(splitProjClass).apply(this);
         AbstractProject<?,?> intProject = projectType2Supplier.get(intProjClass).apply(this);
         AbstractProject<?,?> joinProject = projectType2Supplier.get(joinProjClass).apply(this);

--- a/src/test/java/join/JoinTriggerTest.java
+++ b/src/test/java/join/JoinTriggerTest.java
@@ -201,7 +201,6 @@ public class JoinTriggerTest extends BasicJoinPluginTest {
                 "SUCCESS");
         splitProject.getPublishersList().add(before);
         final WebClient webClient = createWebClient();
-        webClient.setThrowExceptionOnFailingAjax(false);
         final HtmlPage configPage = webClient.getPage(splitProject, "configure");
 
         submit(configPage.getFormByName("config"));
@@ -217,7 +216,6 @@ public class JoinTriggerTest extends BasicJoinPluginTest {
 
         final JoinTrigger before = splitProject.getPublishersList().get(JoinTrigger.class);
         final WebClient webClient = createWebClient();
-        webClient.setThrowExceptionOnFailingAjax(false);
         final HtmlPage configPage = webClient.getPage(splitProject, "configure");
 
         submit(configPage.getFormByName("config"));

--- a/src/test/java/join/RenameTest.java
+++ b/src/test/java/join/RenameTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import static org.junit.Assert.*;
 
 /**
- * @author: <a hef="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @author: <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 public class RenameTest extends BasicJoinPluginTest {
 


### PR DESCRIPTION
- Make matrix-project dependency optional
- Use current parent POM, raising core dep to 1.625.x
- Fix dependencies as needed

Also add Jenkinsfile for ci.jenkins.io CI builds.

---

Just in case someone still cares about this plugin.

Not tested interactively.